### PR TITLE
composer: drop defaults

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,5 @@
             "Spatie\\Activitylog\\": "src/"
         }
     },
-    "license": "MIT",
-    "minimum-stability": "stable"
+    "license": "MIT"
 }


### PR DESCRIPTION
By default uses `stable` https://getcomposer.org/doc/04-schema.md#minimum-stability